### PR TITLE
import requests

### DIFF
--- a/TSIClient/TSIClient.py
+++ b/TSIClient/TSIClient.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import json
+import requests
+
 
 class TSIClient():
     """


### PR DESCRIPTION
Hi,

I would like to use your SDK, but was not able to do because the request import is missing in `TSIClient.py`.

I tested this by installing my fork of your project with the additional import.
````
pip install git+https://github.com/rafaelschlatter/TSIClient
````

I was able to use `client.getEnviroment()`, which returns the DataAccessFQDN.

Regards,
Rafael