### PR TITLE
More unittests + removed .pytest_cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 __pycache__/
+.pytest_cache
+.vscode
 test.py
 test_raw.py
 *.DS_Store

--- a/.pytest_cache/README.md
+++ b/.pytest_cache/README.md
@@ -1,8 +1,0 @@
-# pytest cache directory #
-
-This directory contains data from the pytest's cache plugin,
-which provides the `--lf` and `--ff` options, as well as the `cache` fixture.
-
-**Do not** commit this to version control.
-
-See [the docs](https://docs.pytest.org/en/latest/cache.html) for more information.

--- a/.pytest_cache/v/cache/nodeids
+++ b/.pytest_cache/v/cache/nodeids
@@ -1,3 +1,0 @@
-[
-  "test_collection.py::TestClass::()::test_function_works"
-]

--- a/test_collection.py
+++ b/test_collection.py
@@ -40,11 +40,31 @@ class MockURLs():
     oauth_url = "https://login.microsoftonline.com/{}/oauth2/token".format("yet_another_tenant_id")
     env_url = "https://api.timeseries.azure.com/environments"
     hierarchies_url = "https://{}.env.timeseries.azure.com/timeseries/hierarchies".format("00000000-0000-0000-0000-000000000000")
+    types_url = "https://{}.env.timeseries.azure.com/timeseries/types".format("00000000-0000-0000-0000-000000000000")
 
 
 class MockResponses():
     """This class holds mocked request responses which can be used across tests.
     """
+    mock_types = {
+        "types": [
+            {
+            "id": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
+            "name": "DefaultType",
+            "description": "My Default type",
+            "variables": {
+                "EventCount": {
+                "kind": "aggregate",
+                "filter": None,
+                "aggregation": {
+                    "tsx": "count()"
+                }
+                }
+            }
+            }
+        ],
+        "continuationToken": "aXsic2tpcCI6MTAwMCwidGFrZSI6MTAwMH0="
+    }
 
     mock_hierarchies = {
         "hierarchies": [
@@ -106,8 +126,36 @@ class TestTSIClient():
         resp = client.getHierarchies()
 
         assert len(resp["hierarchies"]) == 1
+        assert type(resp["hierarchies"]) is list
+        assert type(resp["hierarchies"][0]) is dict
         assert resp["hierarchies"][0]["id"] == "6e292e54-9a26-4be1-9034-607d71492707"
         
+
+    def test_getTypes_success(self, requests_mock):
+        requests_mock.request(
+            "GET",
+            MockURLs.types_url,
+            json=MockResponses.mock_types
+        )
+        requests_mock.request(
+            "POST",
+            MockURLs.oauth_url,
+            json=MockResponses.mock_oauth
+        )
+        requests_mock.request(
+            "GET", 
+            MockURLs.env_url, 
+            json=MockResponses.mock_environments
+        )
+
+        client = create_TSIClient()
+        resp = client.getTypes()
+
+        assert len(resp["types"]) == 1
+        assert type(resp["types"]) is list
+        assert type(resp["types"][0]) is dict
+        assert resp["types"][0]["id"] == "1be09af9-f089-4d6b-9f0b-48018b5f7393"
+
 
 def create_TSIClient():
     """        

--- a/test_collection.py
+++ b/test_collection.py
@@ -104,6 +104,24 @@ class TestTSIClient():
         client = create_TSIClient()
         assert client
 
+
+    def test_getEnvironment_success(self, requests_mock):
+        requests_mock.request(
+            "POST",
+            MockURLs.oauth_url,
+            json=MockResponses.mock_oauth
+        )
+        requests_mock.request(
+            "GET", 
+            MockURLs.env_url, 
+            json=MockResponses.mock_environments
+        )
+
+        client = create_TSIClient()
+        env_id = client.getEnviroment()
+
+        assert env_id == "00000000-0000-0000-0000-000000000000"
+
     
     def test_getHierarchies_success(self, requests_mock):
         requests_mock.request(


### PR DESCRIPTION
Hi,

This PR contains unit tests for `getTypes()` and `getEnviroment()`. I also deleted the `.pytest_cache` folder, since this does not need to be in version control.

Regards,
Rafael