### PR TITLE
Raising appropriate exceptions & timeout requests

### DIFF
--- a/TSIClient/TSIClient.py
+++ b/TSIClient/TSIClient.py
@@ -56,11 +56,19 @@ TODO:
         headers = {
             'Content-Type': "application/x-www-form-urlencoded",
             'cache-control': "no-cache"
-            }
-        
-        response = requests.request("POST", url, data=payload, headers=headers)
-        if response.text:
-            jsonResp = json.loads(response.text)
+        }
+
+        try:
+            response = requests.request("POST", url, data=payload, headers=headers, timeout=10)
+            response.raise_for_status()
+        except requests.exceptions.ConnectTimeout:
+            print("TSIClient: The request to the TSI api timed out.")
+            raise
+        except requests.exceptions.HTTPError:
+            print("TSIClient: The request to the TSI api returned an unsuccessfull status code.")
+            raise
+
+        jsonResp = json.loads(response.text)
         tokenType = jsonResp['token_type']
         authorizationToken = tokenType +" " + jsonResp['access_token']
         return authorizationToken

--- a/TSIClient/TSIClient.py
+++ b/TSIClient/TSIClient.py
@@ -3,6 +3,7 @@
 import json
 import pandas as pd
 import requests
+import logging
 
 
 class TSIClient():
@@ -62,10 +63,10 @@ TODO:
             response = requests.request("POST", url, data=payload, headers=headers, timeout=10)
             response.raise_for_status()
         except requests.exceptions.ConnectTimeout:
-            print("TSIClient: The request to the TSI api timed out.")
+            logging.error("TSIClient: The request to the TSI api timed out.")
             raise
         except requests.exceptions.HTTPError:
-            print("TSIClient: The request to the TSI api returned an unsuccessfull status code.")
+            logging.error("TSIClient: The request to the TSI api returned an unsuccessfull status code.")
             raise
 
         jsonResp = json.loads(response.text)

--- a/test_collection.py
+++ b/test_collection.py
@@ -104,6 +104,42 @@ class TestTSIClient():
         client = create_TSIClient()
         assert client
 
+    def test__getToken_success(self, requests_mock):
+        requests_mock.request(
+            "POST",
+            MockURLs.oauth_url,
+            json=MockResponses.mock_oauth
+        )
+        
+        client = create_TSIClient()
+        token = client._getToken()
+
+        assert token == "some_type token"
+
+
+    def test__getToken_raises_HTTPError(self, requests_mock):
+        requests_mock.request(
+            "POST",
+            MockURLs.oauth_url,
+            exc=requests.exceptions.HTTPError
+        )
+        
+        client = create_TSIClient()
+        with pytest.raises(requests.exceptions.HTTPError):
+            token = client._getToken()
+
+
+    def test__getToken_raises_ConnectTimeout(self, requests_mock):
+        requests_mock.request(
+            "POST",
+            MockURLs.oauth_url,
+            exc=requests.exceptions.ConnectTimeout
+        )
+        
+        client = create_TSIClient()
+        with pytest.raises(requests.exceptions.ConnectTimeout):
+            token = client._getToken()
+
 
     def test_getEnvironment_success(self, requests_mock):
         requests_mock.request(
@@ -147,7 +183,7 @@ class TestTSIClient():
         assert type(resp["hierarchies"]) is list
         assert type(resp["hierarchies"][0]) is dict
         assert resp["hierarchies"][0]["id"] == "6e292e54-9a26-4be1-9034-607d71492707"
-        
+
 
     def test_getTypes_success(self, requests_mock):
         requests_mock.request(


### PR DESCRIPTION
Hi,

This PR includes:
- (1) a suggested way of handling exceptions in the SDK
- (2) introduces a timeout for requests.

(1)
All methods that make a request to the TSI api check the success of this request with the following code (example is from `_getToken()`):
````python
if response.text:
    jsonResp = json.loads(response.text)
tokenType = jsonResp['token_type']
````

If `response.text` is none, the 3rd line will fail, which makes the if statement obsolete. Instead of checking the `text` attribute, I suggest to raise exceptions when the request returns an unsuccessful status code. This is what `response.raise_for_status()` does. All HTTP errors are then captured, a meaningful error message from TSIClient is added and the exception is re-raised. This conserves the full stacktrace.

This could be expanded more, by giving specific error messages based on the status code (e.g. the message for `401 - Unauthorized` could be: "Please check your TSI client secret and make sure the service principal has access rights to the TSI environment").

(2)
The `requests` library suggests to have timeouts for all requests. Leaving away the `timeout` argument might cause the SDK to hang indefinitely. I added a very generous timeout of 10 seconds.

Let me know what you think about this, I just implemented this for `_getToken()` for now, since I don't know how you want to handle errors.

Regards,
Rafael