### PR TITLE
Use codecov.io for test coverage reports (pipeline might fail)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The TSIClient is not yet on PyPi, but you can install it directly from GitHub:
 pip install git+https://github.com/RaaLabs/TSIClient.git
 ````
 ## Quickstart
-Instantiate the TSIClient to query your TSI environment. Use the credentials from your service principal in Azure that has access to the TSI environment.
+Instantiate the TSIClient to query your TSI environment. Use the credentials from your service principal in Azure that has access to the TSI environment (you can also use environment variables to instantiate the TSIClient, check the documentation).
 
 ````python
 from TSIClient import TSIClient as tsi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # TSIClient
 [![Build Status](https://dev.azure.com/raalabs/One%20Operation%20Analytics%20Serving/_apis/build/status/RaaLabs.TSIClient?branchName=master)](https://dev.azure.com/raalabs/One%20Operation%20Analytics%20Serving/_build/latest?definitionId=8&branchName=master)
+[![codecov](https://codecov.io/gh/rafaelschlatter/TSIClient/branch/master/graph/badge.svg)](https://codecov.io/gh/rafaelschlatter/TSIClient)
 [![Documentation Status](https://readthedocs.org/projects/tsiclient/badge/?version=latest)](https://tsiclient.readthedocs.io/en/latest/?badge=latest)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/d73dafb558f64d8580a4a87517c32340)](https://www.codacy.com/manual/rafaelschlatter/TSIClient?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=rafaelschlatter/TSIClient&amp;utm_campaign=Badge_Grade)
 

--- a/TSIClient/TSIClient.py
+++ b/TSIClient/TSIClient.py
@@ -17,8 +17,8 @@ class TSIClient():
     is retrieved in form of a pandas dataframe, which allows subsequent analysis
     by data analysts, data scientists and developers.
 
-    It can be instantiated either by arguments or by environment variables (if env
-    variables are set, they take precedence even when function arguments are specified).
+    It can be instantiated either by arguments or by environment variables (if arguments
+    are specified, they take precedence even when environment variables are set).
 
     Args:
         enviroment (str): The name of the Azure TSI environment.
@@ -63,11 +63,11 @@ class TSIClient():
             tenant_id=None
         ):
         self._apiVersion = "2018-11-01-preview"
-        self._applicationName = os.getenv("TSICLIENT_APPLICATION_NAME", applicationName)
-        self._enviromentName = os.getenv("TSICLIENT_ENVIRONMENT_NAME", enviroment)
-        self._client_id = os.getenv("TSICLIENT_CLIENT_ID", client_id)
-        self._client_secret = os.getenv("TSICLIENT_CLIENT_SECRET", client_secret)
-        self._tenant_id = os.getenv("TSICLIENT_TENANT_ID", tenant_id)
+        self._applicationName = applicationName if applicationName is not None else os.environ["TSICLIENT_APPLICATION_NAME"]
+        self._enviromentName = enviroment if enviroment is not None else os.environ["TSICLIENT_ENVIRONMENT_NAME"]
+        self._client_id = client_id if client_id is not None else os.environ["TSICLIENT_CLIENT_ID"]
+        self._client_secret = client_secret if client_secret is not None else os.environ["TSICLIENT_CLIENT_SECRET"]
+        self._tenant_id = tenant_id if tenant_id is not None else os.environ["TSICLIENT_TENANT_ID"]
 
 
     def _getToken(self):
@@ -113,6 +113,29 @@ class TSIClient():
         return authorizationToken
 
 
+    def _create_querystring(self, useWarmStore=None):
+        """Creates the querystring for an api request.
+        
+        Can be used in all api requests in TSIClient.
+
+        Args:
+            useWarmStore (bool): A boolean to indicate the storeType. Defaults to None,
+                in which case no storeType param is included in the querystring.
+
+        Returns:
+            dict: The querystring with the api-version and optionally the storeType.
+        """
+
+        if useWarmStore == None:
+            return {"api-version": self._apiVersion}
+
+        else:
+            return {
+                "api-version": self._apiVersion,
+                "storeType": "WarmStore" if useWarmStore == True else "ColdStore"
+            }
+
+
     def getEnviroment(self):
         """Gets the id of the environment specified in the TSIClient class constructor.
 
@@ -131,7 +154,7 @@ class TSIClient():
         authorizationToken = self._getToken()
         url = "https://api.timeseries.azure.com/environments"
         
-        querystring = {"api-version":self._apiVersion}
+        querystring = self._create_querystring()
         
         payload = ""
         headers = {
@@ -181,7 +204,7 @@ class TSIClient():
         url = "https://{environmentId}.env.timeseries.azure.com/availability".format(
             environmentId=environmentId,
         )
-        querystring = {"api-version": self._apiVersion}
+        querystring = self._create_querystring()
         payload = ""
         headers = {
             'x-ms-client-application-name': self._applicationName,
@@ -227,7 +250,7 @@ class TSIClient():
 
         url = "https://" + environmentId + ".env.timeseries.azure.com/timeseries/instances/"
         
-        querystring = {"api-version":self._apiVersion}
+        querystring = self._create_querystring()
         payload = ""
         
         headers = {
@@ -277,7 +300,7 @@ class TSIClient():
         authorizationToken = self._getToken()
 
         url = "https://" + environmentId + ".env.timeseries.azure.com/timeseries/hierarchies"
-        querystring = {"api-version":self._apiVersion}
+        querystring = self._create_querystring()
         payload = ""
         headers = {
             'x-ms-client-application-name': self._applicationName,
@@ -323,7 +346,7 @@ class TSIClient():
         authorizationToken = self._getToken()
 
         url = "https://" + environmentId + ".env.timeseries.azure.com/timeseries/types"
-        querystring = {"api-version":self._apiVersion}
+        querystring = self._create_querystring()
         payload = ""
         headers = {
             'x-ms-client-application-name': self._applicationName,
@@ -369,8 +392,7 @@ class TSIClient():
 
         url = "https://" + environmentId + ".env.timeseries.azure.com/timeseries/instances/$batch"
         
-        print(url)
-        querystring = {"api-version":self._apiVersion}
+        querystring = self._create_querystring()
 
         headers = {
             'x-ms-client-application-name': self._applicationName,
@@ -399,8 +421,7 @@ class TSIClient():
         payload = {"delete":{"timeSeriesIds":instancesList}}
         url = "https://" + environmentId + ".env.timeseries.azure.com/timeseries/instances/$batch"
         
-        print(url)
-        querystring = {"api-version":self._apiVersion}
+        querystring = self._create_querystring()
         
         headers = {
             'x-ms-client-application-name': self._applicationName,
@@ -414,8 +435,6 @@ class TSIClient():
         # Test if response body contains sth.
         if response.text:
             jsonResponse = json.loads(response.text)
-        
-        print(jsonResponse)
         
         return jsonResponse
 
@@ -433,9 +452,8 @@ class TSIClient():
         authorizationToken = self._getToken()
         payload = {"delete":{"timeSeriesIds":instancesList}}
         url = "https://" + environmentId + ".env.timeseries.azure.com/timeseries/instances/$batch"
-        
-        print(url)
-        querystring = {"api-version":self._apiVersion}
+
+        querystring = self._create_querystring()
         
         headers = {
             'x-ms-client-application-name': self._applicationName,
@@ -573,12 +591,9 @@ class TSIClient():
         authorizationToken = self._getToken()
         df = None
         url = "https://" + environmentId + ".env.timeseries.azure.com/timeseries/query?"
-        querystring = {
-            "api-version": self._apiVersion,
-            "storeType": "WarmStore" if useWarmStore == True else "ColdStore"
-        }
+        querystring = self._create_querystring(useWarmStore=useWarmStore)
         timeseries = self.getIdByName(variables)
-        for i in range(0, len(timeseries)):
+        for i, _ in enumerate(timeseries):
             if timeseries[i] == None:
                 logging.error("No such tag: {tag}".format(tag=variables[i]))
                 continue
@@ -671,10 +686,7 @@ class TSIClient():
         authorizationToken = self._getToken()
         df = None
         url = "https://" + environmentId + ".env.timeseries.azure.com/timeseries/query?"
-        querystring = {
-            "api-version": self._apiVersion,
-            "storeType": "WarmStore" if useWarmStore == True else "ColdStore"
-        }
+        querystring = self._create_querystring(useWarmStore=useWarmStore)
         timeseries = self.getIdByDescription(variables)
         if aggregate != None:
             aggregate = {"tsx": "{0!s}($value)".format(aggregate)}
@@ -682,7 +694,7 @@ class TSIClient():
         else:
             dict_key = "getSeries"
 
-        for i in range(0, len(timeseries)):
+        for i, _ in enumerate(timeseries):
             if timeseries[i] == None:
                 logging.error("No such tag: {tag}".format(tag=variables[i]))
                 continue
@@ -774,17 +786,14 @@ class TSIClient():
         authorizationToken = self._getToken()
         df = None
         url = "https://" + environmentId + ".env.timeseries.azure.com/timeseries/query?"
-        querystring = {
-            "api-version": self._apiVersion,
-            "storeType": "WarmStore" if useWarmStore == True else "ColdStore"
-        }
+        querystring = self._create_querystring(useWarmStore=useWarmStore)
         if aggregate != None:
             aggregate = {"tsx": "{0!s}($value)".format(aggregate)}
             dict_key = "aggregateSeries"
         else:
             dict_key = "getSeries"
 
-        for i in range(0, len(timeseries)):
+        for i, _ in enumerate(timeseries):
             if timeseries[i] == None:
                 logging.error("No such tag: {tag}".format(tag=timeseries[i]))
                 continue
@@ -847,3 +856,4 @@ class TSIClient():
             finally:
                 logging.critical("Loaded data for tag: {tag}".format(tag=timeseries[i]))
         return df
+ 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,10 @@ steps:
   displayName: 'pytest'
 
 - script: |
+    bash <(curl -s https://codecov.io/bash)
+  displayName: 'Upload to codecov.io'
+
+- script: |
     python setup.py sdist
   displayName: 'Artifact creation'
   

--- a/tests/mock_responses.py
+++ b/tests/mock_responses.py
@@ -1,0 +1,169 @@
+class MockURLs():
+    """This class holds mock urls that can be used to mock requests to the TSI environment.
+    Note that there are dependencies between the MockURLs, the MockResponses and the parameters used
+    in "create_TSICLient".
+    """
+
+    oauth_url = "https://login.microsoftonline.com/{}/oauth2/token".format("yet_another_tenant_id")
+    env_url = "https://api.timeseries.azure.com/environments"
+    hierarchies_url = "https://{}.env.timeseries.azure.com/timeseries/hierarchies".format("00000000-0000-0000-0000-000000000000")
+    types_url = "https://{}.env.timeseries.azure.com/timeseries/types".format("00000000-0000-0000-0000-000000000000")
+    instances_url = "https://{}.env.timeseries.azure.com/timeseries/instances/".format("00000000-0000-0000-0000-000000000000")
+    environment_availability_url = "https://{}.env.timeseries.azure.com/availability".format("00000000-0000-0000-0000-000000000000")
+    query_getseries_url = "https://{}.env.timeseries.azure.com/timeseries/query?".format("00000000-0000-0000-0000-000000000000")
+
+
+class MockResponses():
+    """This class holds mocked request responses which can be used across tests.
+    The json responses are taken from the official Azure TSI api documentation.
+    """
+    mock_types = {
+        "types": [
+            {
+                "id": "1be09af9-f089-4d6b-9f0b-48018b5f7393",
+                "name": "DefaultType",
+                "description": "My Default type",
+                "variables": {
+                    "EventCount": {
+                    "kind": "aggregate",
+                    "filter": None,
+                    "aggregation": {
+                        "tsx": "count()"
+                    }
+                    }
+                }
+            }
+        ],
+        "continuationToken": "aXsic2tpcCI6MTAwMCwidGFrZSI6MTAwMH0="
+    }
+
+    mock_hierarchies = {
+        "hierarchies": [
+            {
+                "id": "6e292e54-9a26-4be1-9034-607d71492707",
+                "name": "Location",
+                "source": {
+                    "instanceFieldNames": [
+                    "state",
+                    "city"
+                    ]
+                }
+            }
+        ],
+        "continuationToken": "aXsic2tpcCI6MTAwMCwidGFrZSI6MTAwMH0="
+    }
+
+    mock_oauth = {
+        "token_type": "some_type",
+        "access_token": "token"
+    }
+
+    mock_environments = {
+        "environments": [
+            {
+                "displayName":"Test_Environment",
+                "environmentFqdn": "00000000-0000-0000-0000-000000000000.env.timeseries.azure.com",
+                "environmentId": "00000000-0000-0000-0000-000000000000",
+                "resourceId": "resourceId"
+            }
+        ]
+    }
+
+    mock_instances = {
+        "instances": [
+            {
+                "typeId": "9b84e946-7b36-4aa0-9d26-71bf48cb2aff",
+                "name": "F1W7.GS1",
+                "timeSeriesId": [
+                    "006dfc2d-0324-4937-998c-d16f3b4f1952",
+                    "T1"
+                ],
+                "description": "ContosoFarm1W7_GenSpeed1",
+                "hierarchyIds": [
+                    "33d72529-dd73-4c31-93d8-ae4e6cb5605d"
+                ],
+                "instanceFields": {
+                    "Name": "GeneratorSpeed",
+                    "Plant": "Contoso Plant 1",
+                    "Unit": "W7",
+                    "System": "Generator System"
+                }
+            }
+        ],
+        "continuationToken": "aXsic2tpcCI6MTAwMCwidGFrZSI6MTAwMH0="
+    }
+
+    mock_environment_availability = {
+        "availability": {
+            "intervalSize": "PT1H",
+            "distribution": {
+                "2019-03-27T04:00:00Z": 432447,
+                "2019-03-27T05:00:00Z": 432340,
+                "2019-03-27T06:00:00Z": 432451,
+                "2019-03-27T07:00:00Z": 432436,
+                "2019-03-26T13:00:00Z": 386247,
+                "2019-03-27T00:00:00Z": 436968,
+                "2019-03-27T01:00:00Z": 432509,
+                "2019-03-27T02:00:00Z": 432487
+            },
+            "range": {
+                "from": "2019-03-14T06:38:27.153Z",
+                "to": "2019-03-27T03:57:11.697Z"
+            }
+        }
+    }
+
+    mock_query_getseries_success = {
+        "timestamps": [
+            "2016-08-01T00:00:10Z",
+            "2016-08-01T00:00:11Z",
+            "2016-08-01T00:00:12Z",
+            "2016-08-01T00:00:13Z",
+            "2016-08-01T00:00:14Z",
+            "2016-08-01T00:00:15Z",
+            "2016-08-01T00:00:16Z",
+            "2016-08-01T00:00:17Z",
+            "2016-08-01T00:00:18Z",
+            "2016-08-01T00:00:19Z",
+            "2016-08-01T00:00:20Z"
+        ],
+        "properties": [
+            {
+                "name": "AverageTest",
+                "type": "Double",
+                "values": [
+                    65.125,
+                    65.375,
+                    65.625,
+                    65.875,
+                    66.125,
+                    66.375,
+                    66.625,
+                    66.875,
+                    67.125,
+                    67.375,
+                    67.625
+                ]
+            }
+        ],
+        "progress": 50,
+        "continuationToken": "aXsic2tpcCI6MTAxYZwidGFrZSI6MTAwMH0="
+    }
+
+    mock_query_getseries_tsistoreerror = {
+        "error" : {
+            "code" : "...",
+            "message" : "...",
+            "innerError" : {  
+                "code" : "TimeSeriesQueryNotSupported",
+                "message" : "...",
+            }
+        }
+    }
+
+    mock_query_getseries_tsiqueryerror = {
+        "error" : {
+            "code" : "...",
+            "message" : "...",
+        }
+    }


### PR DESCRIPTION
Hi Anders,

I added a code coverage badge from codecov.io to track test coverage.

At the moment the link in the badge points at my fork. The codecov script i added to the Azure pipeline will probably fail on this pull request, because I cannot add RaaLabs/TSIClient to my codecov account.

You can add it and setup code coverage, by following these steps:
- Create an account at https://codecov.io/ (can login with GitHub)
- Install the codecov GitHub integration for RaaLabs/TSIClient, https://github.com/settings/installations/7547723
- **No changes required** to the `azure-piplines.yml` file, since this is generic and codecov does not need a token or secret to interact with the repo
- Trigger the build pipeline again to verify it runs successful

Regards,
Rafael