### PR TITLE
Replace dead pypi badges.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![codecov](https://codecov.io/gh/rafaelschlatter/TSIClient/branch/master/graph/badge.svg)](https://codecov.io/gh/rafaelschlatter/TSIClient)
 [![Documentation Status](https://readthedocs.org/projects/raalabs-tsiclient/badge/?version=latest)](https://raalabs-tsiclient.readthedocs.io/en/latest/?badge=latest)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/d73dafb558f64d8580a4a87517c32340)](https://www.codacy.com/manual/rafaelschlatter/TSIClient?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=rafaelschlatter/TSIClient&amp;utm_campaign=Badge_Grade)
-![PyPI](https://img.shields.io/pypi/v/TSIClient)
-![PyPI - Downloads](https://img.shields.io/pypi/dm/TSIClient)
+[![PyPI version](https://badge.fury.io/py/TSIClient.svg)](https://badge.fury.io/py/TSIClient)
+[![Downloads](https://pepy.tech/badge/tsiclient/month)](https://pepy.tech/project/tsiclient/month)
 
 The TSIClient is a Python SDK for Microsoft Azure time series insights. It provides methods to conveniently retrieve your data and is designed
 for analysts, data scientists and developers working with time series data in Azure TSI.


### PR DESCRIPTION
pypistats.org is down since some days, replaced the download stats badge with one from PePy.

Also added another PyPi version badge, we can now click on the badges to get to the PyPi package.