### PR TITLE
Automatically install submodules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 with open('README.md') as f:
@@ -6,7 +6,7 @@ with open('README.md') as f:
 
 setup(
   name = 'TSIClient',
-  packages = ['TSIClient'],
+  packages = find_packages(),
   version = '1.2.0',
   license='MIT',
   long_description=long_description,


### PR DESCRIPTION
The `setup.py` only installed the `TSIClient` package, but not the subpackages, and therefore `pip install` would not install all code and the TSIClient was not usable. This PR should fix the issue, `find_packages()` adds subpackages as long as there is an `__init__.py` file.