### PR TITLE
WIP: Reduce complexity

### DIFF
--- a/TSIClient/query/query_api.py
+++ b/TSIClient/query/query_api.py
@@ -109,11 +109,11 @@ class QueryApi():
         Args:
             aggregateList (list): List of the aggregation methods to be used without interpolation:
                 ("min", "max", "sum", "avg", "first", "last", "median", "stdev").
-            The aggregation method to be used with interpolation:
+                The aggregation method to be used with interpolation:
                 ("twsum", "twavg", "left", "right")
             interpolationList (list): A list of interpolation methods. Either Linear or Step.
             interpolationSpanList (str): The time interval that is used during aggregation. Must follow the ISO-8601 duration format.
-                Example: interpolation Boundary span ="P1D", for 1 day to the left and right of the search span to be used for Interpolation..
+                Example: interpolation Boundary span ="P1D", for 1 day to the left and right of the search span to be used for Interpolation.
         Returns:
             A tuple of lists to apply in the payload consisiting of the InlineVariables and the 
             projectedVariables. 
@@ -252,7 +252,17 @@ class QueryApi():
         return timeSeriesIds
 
 
-    def getDataByName(self, variables, timespan, interval, aggregateList=None, interpolationList=None, interpolationSpanList=None, requestBodyType=None, useWarmStore=False):
+    def getDataByName(
+        self,
+        variables,
+        timespan,
+        interval,
+        aggregateList=None,
+        interpolationList=None,
+        interpolationSpanList=None,
+        requestBodyType=None,
+        useWarmStore=False
+    ):
         """Returns a dataframe with timestamps and values for the time series names given in "variables".
 
         Can be used to return data for single and multiple timeseries. Names must be exact matches.
@@ -263,7 +273,14 @@ class QueryApi():
                 Example: timespan=['2019-12-12T15:35:11.68Z', '2019-12-12T17:02:05.958Z']
             interval (str): The time interval that is used during aggregation. Must follow the ISO-8601 duration format.
                 Example: interval="PT1M", for 1 minute aggregation.
-            aggregate (str): Supports "min", "max", "avg". Can be None, in which case the raw events are returned. Defaults to None.
+            aggregateList (list): List of the aggregation methods to be used without interpolation:
+                ("min", "max", "sum", "avg", "first", "last", "median", "stdev").
+                The aggregation method to be used with interpolation:
+                ("twsum", "twavg", "left", "right")
+            interpolationList (list): A list of interpolation methods. Either "Linear" or "Step".
+            interpolationSpanList (str): The time interval that is used during aggregation. Must follow the ISO-8601 duration format.
+                Example: interpolation Boundary span ="P1D", for 1 day to the left and right of the search span to be used for Interpolation.
+            requestBodyType (str): Type of the request, either "getSeries", "aggregateSeries" or "getEvents".
             useWarmStore (bool): If True, the query is executed on the warm storage (free of charge), otherwise on the cold storage. Defaults to False.
 
         Returns:
@@ -280,7 +297,7 @@ class QueryApi():
             ...     variables=["timeseries_name_1", "timeseries_name_2"],
             ...     timespan=["2020-01-25T10:00:11.68Z", "2020-01-26T13:45:11.68Z"],
             ...     interval="PT5M",
-            ...     aggregate="avg",
+            ...     aggregateList=["avg"],
             ...     useWarmStore=False
             ... )
         """
@@ -321,7 +338,18 @@ class QueryApi():
         )
 
 
-    def getDataByDescription(self, variables, TSName, timespan, interval, aggregateList=None, interpolationList=None, interpolationSpanList=None, requestBodyType=None,useWarmStore=False):
+    def getDataByDescription(
+        self,
+        variables,
+        TSName,
+        timespan,
+        interval,
+        aggregateList=None,
+        interpolationList=None,
+        interpolationSpanList=None,
+        requestBodyType=None,
+        useWarmStore=False
+    ):
         """Returns a dataframe with timestamp and values for the time series that match the description given in "variables".
 
         Can be used to return data for single and multiple timeseries. Descriptions must be exact matches.
@@ -334,7 +362,14 @@ class QueryApi():
                 Example: timespan=['2019-12-12T15:35:11.68Z', '2019-12-12T17:02:05.958Z']
             interval (str): The time interval that is used during aggregation. Must follow the ISO-8601 duration format.
                 Example: interval="PT1M", for 1 minute aggregation. If "aggregate" is None, the raw events are returned.
-            aggregate (str): Supports "min", "max", "avg". Can be None, in which case the raw events are returned. Defaults to None.
+            aggregateList (list): List of the aggregation methods to be used without interpolation:
+                ("min", "max", "sum", "avg", "first", "last", "median", "stdev").
+                The aggregation method to be used with interpolation:
+                ("twsum", "twavg", "left", "right")
+            interpolationList (list): A list of interpolation methods. Either "Linear" or "Step".
+            interpolationSpanList (str): The time interval that is used during aggregation. Must follow the ISO-8601 duration format.
+                Example: interpolation Boundary span ="P1D", for 1 day to the left and right of the search span to be used for Interpolation.
+            requestBodyType (str): Type of the request, either "getSeries", "aggregateSeries" or "getEvents".
             useWarmStore (bool): If True, the query is executed on the warm storage (free of charge), otherwise on the cold storage. Defaults to False.
 
         Returns:
@@ -352,7 +387,7 @@ class QueryApi():
             ...     TSName=["my_timeseries_name_1", "my_timeseries_name_2"]
             ...     timespan=["2020-01-25T10:00:11.68Z", "2020-01-26T13:45:11.68Z"],
             ...     interval="PT5M",
-            ...     aggregate="avg",
+            ...     aggregateList=["avg"],
             ...     useWarmStore=False
             ... )
         """
@@ -393,7 +428,17 @@ class QueryApi():
         )
 
 
-    def getDataById(self, timeseries, timespan, interval, aggregateList=None, interpolationList=None, interpolationSpanList=None, requestBodyType=None, useWarmStore=False):
+    def getDataById(
+        self,
+        timeseries,
+        timespan,
+        interval,
+        aggregateList=None,
+        interpolationList=None,
+        interpolationSpanList=None,
+        requestBodyType=None,
+        useWarmStore=False
+    ):
         """Returns a dataframe with timestamp and values for the time series that match the description given in "timeseries".
 
         Can be used to return data for single and multiple timeseries. Timeseries ids must be an exact matches.
@@ -404,7 +449,14 @@ class QueryApi():
                 Example: timespan=['2019-12-12T15:35:11.68Z', '2019-12-12T17:02:05.958Z']
             interval (str): The time interval that is used during aggregation. Must follow the ISO-8601 duration format.
                 Example: interval="PT1M", for 1 minute aggregation. If "aggregate" is None, the raw events are returned.
-            aggregate (str): Supports "min", "max", "avg". Can be None, in which case the raw events are returned. Defaults to None.
+            aggregateList (list): List of the aggregation methods to be used without interpolation:
+                ("min", "max", "sum", "avg", "first", "last", "median", "stdev").
+                The aggregation method to be used with interpolation:
+                ("twsum", "twavg", "left", "right")
+            interpolationList (list): A list of interpolation methods. Either "Linear" or "Step".
+            interpolationSpanList (str): The time interval that is used during aggregation. Must follow the ISO-8601 duration format.
+                Example: interpolation Boundary span ="P1D", for 1 day to the left and right of the search span to be used for Interpolation.
+            requestBodyType (str): Type of the request, either "getSeries", "aggregateSeries" or "getEvents".
             useWarmStore (bool): If True, the query is executed on the warm storage (free of charge), otherwise on the cold storage. Defaults to False.
 
         Returns:
@@ -421,7 +473,7 @@ class QueryApi():
             ...     timeseries=["timeseries_id_1", "timeseries_id_2"],
             ...     timespan=["2020-01-25T10:00:11.68Z", "2020-01-26T13:45:11.68Z"],
             ...     interval="PT5M",
-            ...     aggregate="avg",
+            ...     aggregateList=["avg"],
             ...     useWarmStore=False
             ... )
         """

--- a/TSIClient/query/query_api.py
+++ b/TSIClient/query/query_api.py
@@ -505,10 +505,6 @@ class QueryApi():
             elif requestType == 'getEvents':
                 projectedVarNames = None
 
-            else:
-                raise TSIQueryError(
-                    "TSIClient: Not a valid request type "
-                )
             payload = {
                 requestType: {
                     "timeSeriesId": [timeseries[i]],

--- a/tests/query/test_query_api.py
+++ b/tests/query/test_query_api.py
@@ -123,7 +123,7 @@ class TestQueryApi:
         requests_mock.request("GET", MockURLs.types_url, json=MockResponses.mock_types)
 
         with pytest.raises(TSIQueryError):
-            data_by_id = client.query.getDataById(
+            client.query.getDataById(
                 timeseries=["006dfc2d-0324-4937-998c-d16f3b4f1952"],
                 timespan=["2016-08-01T00:00:10Z", "2016-08-01T00:00:20Z"],
                 interval="PT1S",
@@ -222,7 +222,7 @@ class TestQueryApi:
         requests_mock.request("GET", MockURLs.types_url, json=MockResponses.mock_types)
 
         with pytest.raises(TSIQueryError):
-            data_by_description = client.query.getDataByDescription(
+            client.query.getDataByDescription(
                 variables=[
                     "ContosoFarm1W7_GenSpeed1",
                     "DescriptionOfNonExistantTimeseries",
@@ -285,7 +285,7 @@ class TestQueryApi:
         requests_mock.request("GET", MockURLs.types_url, json=MockResponses.mock_types)
 
         with pytest.raises(TSIQueryError):
-            data_by_name = client.query.getDataByName(
+            client.query.getDataByName(
                 variables=["F1W7.GS1", "NameOfNonExistantTimeseries"],
                 timespan=["2016-08-01T00:00:10Z", "2016-08-01T00:00:20Z"],
                 interval="PT1S",


### PR DESCRIPTION
This PR reduces the complexity/code duplication in the query api (a bit at least, i wanted to do more, but havent had as much time to work on it as I thought).

- Removed the if statement on l. 562 in `query_api`, no need for that since we use `response` anyway later on
- the codeblocks on l. 633 and 693 in `query_api` are identical, changed that to an `else` statement and deleted on block
- rest is updating docstrings/formatting