### PR TITLE
Default azure credential

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,24 @@ Or if you want to get the latest code, directly fom GitHub:
 pip install git+https://github.com/RaaLabs/TSIClient.git
 ````
 ## Quickstart
-Instantiate the TSIClient to query your TSI environment. Use the credentials from your service principal in Azure that has access to the TSI environment (you can also use environment variables to instantiate the TSIClient or provide a specific TSI api version, check the documentation).
+Instantiate the TSIClient to query your TSI environment. Log in to Azure using the Azure CLI:
+````bash
+az login --tenant <your-azure-tenant-id>
+````
+
+Now instantiate the client like this:
 
 ````python
 from TSIClient import TSIClient as tsi
 
 client = tsi.TSIClient(
     enviroment="<your-tsi-env-name>",
-    client_id="<your-client-id>",
-    client_secret="<your-client-secret>",
-    tenant_id="<your-tenant-id>",
     applicationName="<your-app-name>">
 )
 ````
+
+You can check the docs at <https://raalabs-tsiclient.readthedocs.io/en/latest/authentication.html> for more information on authentication, and check
+the old way of authentication (these will be removed in a future version).
 
 You can query your timeseries data by timeseries id, timeseries name or timeseries description. The Microsoft TSI apis support aggregation, so you can specify a sampling freqency and an aggregation method. Refer to the documentation for detailed information.
 

--- a/TSIClient/TSIClient.py
+++ b/TSIClient/TSIClient.py
@@ -65,11 +65,11 @@ class TSIClient():
             tenant_id=None,
             api_version=None
         ):
-        self._applicationName = applicationName if applicationName is not None else os.environ["TSICLIENT_APPLICATION_NAME"]
-        self._environmentName = environment if environment is not None else os.environ["TSICLIENT_ENVIRONMENT_NAME"]
-        self._client_id = client_id if client_id is not None else os.environ["TSICLIENT_CLIENT_ID"]
-        self._client_secret = client_secret if client_secret is not None else os.environ["TSICLIENT_CLIENT_SECRET"]
-        self._tenant_id = tenant_id if tenant_id is not None else os.environ["TSICLIENT_TENANT_ID"]
+        self._applicationName = applicationName if applicationName is not None else os.getenv("TSICLIENT_APPLICATION_NAME")
+        self._environmentName = environment if environment is not None else os.getenv("TSICLIENT_ENVIRONMENT_NAME")
+        self._client_id = client_id if client_id is not None else os.getenv("TSICLIENT_CLIENT_ID")
+        self._client_secret = client_secret if client_secret is not None else os.getenv("TSICLIENT_CLIENT_SECRET")
+        self._tenant_id = tenant_id if tenant_id is not None else os.getenv("TSICLIENT_TENANT_ID")
 
         if self._client_id is not None or self._client_secret is not None or self._tenant_id is not None:
             print("TSIClient deprecation warning:")

--- a/TSIClient/TSIClient.py
+++ b/TSIClient/TSIClient.py
@@ -71,6 +71,13 @@ class TSIClient():
         self._client_secret = client_secret if client_secret is not None else os.environ["TSICLIENT_CLIENT_SECRET"]
         self._tenant_id = tenant_id if tenant_id is not None else os.environ["TSICLIENT_TENANT_ID"]
 
+        if self._client_id is not None or self._client_secret is not None or self._tenant_id is not None:
+            print("TSIClient deprecation warning:")
+            print("------------------------------")
+            print("Authentication by providing service principal details to the constructor of the TSIClient will be removed in a future version.")
+            print("Authentication with the environmental variables TSICLIENT_CLIENT_ID, TSICLIENT_CLIENT_SECRET and TSICLIENT_TENANT_ID will be removed in a future version")
+            print("Authenticate with the DefaultAzureCredential. Check the docs at readthedocs on how to authenticate with your TSI environment: https://raalabs-tsiclient.readthedocs.io/en/latest/authentication.html.")
+
         allowed_api_versions = ["2020-07-31", "2018-11-01-preview"]
         if api_version in allowed_api_versions:
             self._apiVersion = api_version
@@ -80,7 +87,13 @@ class TSIClient():
         else:
             self._apiVersion = "2020-07-31"
 
-        self.authorization = AuthorizationApi()
+        self.authorization = AuthorizationApi(
+            client_id = self._client_id,
+            client_secret = self._client_secret,
+            tenant_id = self._tenant_id,
+            api_version = self._apiVersion
+        )
+
 
         self.common_funcs = CommonFuncs(
             api_version = self._apiVersion

--- a/TSIClient/TSIClient.py
+++ b/TSIClient/TSIClient.py
@@ -80,12 +80,7 @@ class TSIClient():
         else:
             self._apiVersion = "2020-07-31"
 
-        self.authorization = AuthorizationApi(
-            client_id = self._client_id,
-            client_secret = self._client_secret,
-            tenant_id = self._tenant_id,
-            api_version = self._apiVersion
-        )
+        self.authorization = AuthorizationApi()
 
         self.common_funcs = CommonFuncs(
             api_version = self._apiVersion

--- a/TSIClient/authorization/authorization_api.py
+++ b/TSIClient/authorization/authorization_api.py
@@ -3,13 +3,67 @@ import logging
 import json
 from azure.identity import DefaultAzureCredential
 
-
 class AuthorizationApi:
-    def __init__(self):
+    def __init__(self, client_id, client_secret, tenant_id, api_version):
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._tenant_id = tenant_id
         self.credentials = DefaultAzureCredential(exclude_shared_token_cache_credential=True)
 
 
     def _getToken(self):
-        azure_token_object = self.credentials.get_token("https://api.timeseries.azure.com/")
+        """Gets an authorization token from the Azure TSI api which is used to authenticate api calls.
 
-        return f"Bearer {azure_token_object.token}"
+        Returns:
+            str: The authorization token.
+        """
+        if self._client_secret is None or self._client_id is None or self._tenant_id is None:
+            azure_token_object = self.credentials.get_token("https://api.timeseries.azure.com/")
+            return f"Bearer {azure_token_object.token}"
+
+        url = "https://login.microsoftonline.com/{0!s}/oauth2/token".format(
+            self._tenant_id
+        )
+
+        payload = {
+            "grant_type": "client_credentials",
+            "client_id": self._client_id,
+            "client_secret": self._client_secret,
+            "resource": "https%3A%2F%2Fapi.timeseries.azure.com%2F&undefined=",
+        }
+
+        payload = "grant_type={grant_type}&client_id={client_id}&client_secret={client_secret}&resource={resource}".format(
+            **payload
+        )
+
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "cache-control": "no-cache",
+        }
+
+        try:
+            response = requests.request(
+                "POST", url, data=payload, headers=headers, timeout=10
+            )
+            response.raise_for_status()
+        except requests.exceptions.ConnectTimeout:
+            logging.error("TSIClient: The request to the TSI api timed out.")
+            raise
+        except requests.exceptions.HTTPError as e:
+            status_code = e.response.status_code
+            if status_code == 401:
+                logging.error(
+                    "TSIClient: Authentication with the TSI api was unsuccessful. Check your client secret."
+                )
+            else:
+                logging.error(
+                    "TSIClient: The request to the TSI api returned an unsuccessfull status code. Check the stack trace"
+                )
+            raise
+
+        jsonResp = json.loads(response.text)
+        tokenType = jsonResp["token_type"]
+        authorizationToken = tokenType + " " + jsonResp["access_token"]
+
+        return authorizationToken
+

--- a/TSIClient/authorization/authorization_api.py
+++ b/TSIClient/authorization/authorization_api.py
@@ -8,7 +8,10 @@ class AuthorizationApi:
         self._client_id = client_id
         self._client_secret = client_secret
         self._tenant_id = tenant_id
-        self.credentials = DefaultAzureCredential(exclude_shared_token_cache_credential=True)
+        self.credentials = DefaultAzureCredential(
+            exclude_shared_token_cache_credential=True,
+            exclude_visual_studio_code_credential=True
+        )
 
 
     def _getToken(self):

--- a/TSIClient/authorization/authorization_api.py
+++ b/TSIClient/authorization/authorization_api.py
@@ -1,65 +1,15 @@
 import requests
 import logging
 import json
+from azure.identity import DefaultAzureCredential
 
 
 class AuthorizationApi:
-    def __init__(self, client_id, client_secret, tenant_id, api_version):
-        self._client_id = client_id
-        self._client_secret = client_secret
-        self._tenant_id = tenant_id
+    def __init__(self):
+        self.credentials = DefaultAzureCredential(exclude_shared_token_cache_credential=True)
 
 
     def _getToken(self):
-        """Gets an authorization token from the Azure TSI api which is used to authenticate api calls.
+        azure_token_object = self.credentials.get_token("https://api.timeseries.azure.com/")
 
-        Returns:
-            str: The authorization token.
-        """
-
-        url = "https://login.microsoftonline.com/{0!s}/oauth2/token".format(
-            self._tenant_id
-        )
-
-        payload = {
-            "grant_type": "client_credentials",
-            "client_id": self._client_id,
-            "client_secret": self._client_secret,
-            "resource": "https%3A%2F%2Fapi.timeseries.azure.com%2F&undefined=",
-        }
-
-        payload = "grant_type={grant_type}&client_id={client_id}&client_secret={client_secret}&resource={resource}".format(
-            **payload
-        )
-
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded",
-            "cache-control": "no-cache",
-        }
-
-        try:
-            response = requests.request(
-                "POST", url, data=payload, headers=headers, timeout=10
-            )
-            response.raise_for_status()
-        except requests.exceptions.ConnectTimeout:
-            logging.error("TSIClient: The request to the TSI api timed out.")
-            raise
-        except requests.exceptions.HTTPError as e:
-            status_code = e.response.status_code
-            if status_code == 401:
-                logging.error(
-                    "TSIClient: Authentication with the TSI api was unsuccessful. Check your client secret."
-                )
-            else:
-                logging.error(
-                    "TSIClient: The request to the TSI api returned an unsuccessfull status code. Check the stack trace"
-                )
-            raise
-
-        jsonResp = json.loads(response.text)
-        tokenType = jsonResp["token_type"]
-        authorizationToken = tokenType + " " + jsonResp["access_token"]
-
-        return authorizationToken
-        
+        return f"Bearer {azure_token_object.token}"

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -1,6 +1,72 @@
 Authentication with Azure
 =========================
 
+We recommend to your logged in Azure account to authenticate with the TSIClient. For that you need to install
+the Azure CLI. Follow the docs here: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
+
+Log in to Azure with the following command:
+
+.. code-block:: console
+
+    $ az login --tenant <your-azure-tenant-id>
+
+You can find your Azure tenant id by opening the Azure portal > Azure active directory > Overview.
+If you are unable to see your tenant id in AAD, ask your Azure adminstrator for the tenant id.
+
+Once you successfully logged into Azure using the Azure CLI, you can instantiate the TSIClient, you only need to provide
+the `applicationName` and `environment` arguments: 
+
+.. code-block:: python
+
+    >>> from TSIClient import TSIClient as tsi
+    >>> client = tsi.TSIClient(
+    ...     enviroment="<your-tsi-env-name>",
+    ...     applicationName="<your-app-name>">,
+    ...     api_version="2020-07-31"
+    ... )
+
+
 .. warning::
-    Since version 2.1.0 authentication is preferrably done using `DefaultAzureCredential`.
-    Find the relevant docs here: https://docs.microsoft.com/en-us/azure/developer/python/azure-sdk-authenticate?tabs=cmd.
+    Since version 2.1.0 authentication is preferrably done using a `DefaultAzureCredential` from the `azure-identity` package.
+    Authentication by providing constructor arguments or defining these environment variables: `TSICLIENT_CLIENT_ID`, `TSICLIENT_CLIENT_SECRET`, `TSICLIENT_TENANT_ID` will be
+    removed in a future version.
+
+You can still authenticate by passing arguments to the constructor, however,
+this will be removed in a future version. Authentication works through the use of
+a service principal. When you create the service principal in Azure, make sure to
+note down the details, since you need them to use the TSIClient. Note that one instance
+of the TSIClient can only connect to one TSI environment, if you wish to connect to
+multiple TSI environments, you need to create multiple instances of the TSIClient.
+
+.. code-block:: python
+
+    >>> from TSIClient import TSIClient as tsi
+    >>> client = tsi.TSIClient(
+    ...     enviroment="<your-tsi-env-name>",
+    ...     client_id="<your-client-id>",
+    ...     client_secret="<your-client-secret>",
+    ...     tenant_id="<your-tenant-id>",
+    ...     applicationName="<your-app-name>">,
+    ...     api_version="2020-07-31"
+    ... )
+
+Alternatively, you can use environment variables to instantiate the TSIClient.
+Set the following variables (commands for Mac/Linux):
+
+.. code-block:: console
+
+    $ export TSICLIENT_APPLICATION_NAME=<your-app-name>
+    $ export TSICLIENT_ENVIRONMENT_NAME=<your-tsi-env-name>
+    $ export TSICLIENT_CLIENT_ID=<your-client-id>
+    $ export TSICLIENT_CLIENT_SECRET=<your-client-secret>
+    $ export TSICLIENT_TENANT_ID=<your-tenant-id>
+    $ export TSI_API_VERSION="2020-07-31"
+
+Now you can instantiate the TSIClient without passing any arguments. Be aware
+that the constructor arguments take precedence over the environment variables. Specifying the
+TSI api version is optional (defaults to '2020-07-31'). Allowed values are '2018-11-01-preview' and '2020-07-31'.
+
+.. code-block:: python
+
+    >>> from TSIClient import TSIClient as tsi
+    >>> client = tsi.TSIClient()

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -1,3 +1,6 @@
-Authentication
-==============
-To be added ...
+Authentication with Azure
+=========================
+
+.. warning::
+    Since version 2.1.0 authentication is preferrably done using `DefaultAzureCredential`.
+    Find the relevant docs here: https://docs.microsoft.com/en-us/azure/developer/python/azure-sdk-authenticate?tabs=cmd.

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -1,0 +1,3 @@
+Authentication
+==============
+To be added ...

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -1,7 +1,7 @@
 Authentication with Azure
 =========================
 
-We recommend to your logged in Azure account to authenticate with the TSIClient. For that you need to install
+We recommend to use your Azure account to authenticate with the TSIClient. For that you need to install
 the Azure CLI. Follow the docs here: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
 
 Log in to Azure with the following command:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,7 @@ sys.path.insert(0, os.path.abspath('../../'))
 # -- Project information -----------------------------------------------------
 
 project = 'TSIClient'
-copyright = '2020, Raa Labs'
+copyright = '2021, Raa Labs'
 author = 'Raa Labs'
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,6 +16,7 @@ https://docs.microsoft.com/en-us/rest/api/time-series-insights/
    :caption: Table of contents:
 
    installation.rst
+   authentication.rst
    userguide.rst
    _autogen/modules.rst
    developer.rst

--- a/docs/source/userguide.rst
+++ b/docs/source/userguide.rst
@@ -9,44 +9,19 @@ TSIClient.
     APIs. Find it here: https://docs.microsoft.com/en-us/rest/api/time-series-insights/.
 
 
-First you have to instantiate the TSIClient. Authentication works through the use of
-a service principal. When you create the service principal in Azure, make sure to
-note down the details, since you need them to use the TSIClient. Note that one instance
-of the TSIClient can only connect to one TSI environment, if you wish to connect to
-multiple TSI environments, you need to create multiple instances of the TSIClient.
+First you have to instantiate the TSIClient. If you authenticated using the Azure CLI,
+you can instantiate the client like this:
 
 .. code-block:: python
 
     >>> from TSIClient import TSIClient as tsi
     >>> client = tsi.TSIClient(
     ...     enviroment="<your-tsi-env-name>",
-    ...     client_id="<your-client-id>",
-    ...     client_secret="<your-client-secret>",
-    ...     tenant_id="<your-tenant-id>",
     ...     applicationName="<your-app-name>">,
     ...     api_version="2020-07-31"
     ... )
 
-Alternatively, you can use environment variables to instantiate the TSIClient.
-Set the following variables (commands for Mac/Linux):
 
-.. code-block:: console
-
-    $ export TSICLIENT_APPLICATION_NAME=<your-app-name>
-    $ export TSICLIENT_ENVIRONMENT_NAME=<your-tsi-env-name>
-    $ export TSICLIENT_CLIENT_ID=<your-client-id>
-    $ export TSICLIENT_CLIENT_SECRET=<your-client-secret>
-    $ export TSICLIENT_TENANT_ID=<your-tenant-id>
-    $ export TSI_API_VERSION="2020-07-31"
-
-Now you can instantiate the TSIClient without passing any arguments. Be aware
-that the constructor arguments take precedence over the environment variables. Specifying the
-TSI api version is optional (defaults to '2020-07-31'). Allowed values are '2018-11-01-preview' and '2020-07-31'.
-
-.. code-block:: python
-
-    >>> from TSIClient import TSIClient as tsi
-    >>> client = tsi.TSIClient()
 
 You can verify that the TSIClient is pointing at the right TSI environment by running the
 following command. It returns the environment id, which you can compare with your data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 alabaster==0.7.12
 atomicwrites==1.3.0
 attrs==19.3.0
+azure-identity==1.4.0
 Babel==2.8.0
 certifi==2019.11.28
 chardet==3.0.4
@@ -21,8 +22,8 @@ py==1.8.0
 Pygments==2.5.2
 pyparsing==2.4.5
 pytest==5.2.3
-pytest-azurepipelines==0.8.0
 pytest-cov==2.8.1
+pytest-mock==3.5.1
 python-dateutil==2.8.1
 pytz==2019.3
 requests==2.22.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 alabaster==0.7.12
 atomicwrites==1.3.0
 attrs==19.3.0
-azure-identity==1.4.0
+azure-identity==1.5.0
 Babel==2.8.0
 certifi==2019.11.28
 chardet==3.0.4

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 setup(
     name="TSIClient",
     packages=find_packages(),
-    version="2.1.1",
+    version="2.1.2",
     license="MIT",
     description="The TSIClient is a Python SDK for Microsoft Azure time series insights.",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 setup(
     name="TSIClient",
     packages=find_packages(),
-    version="2.0.0",
+    version="2.1.0",
     license="MIT",
     description="The TSIClient is a Python SDK for Microsoft Azure time series insights.",
     long_description=long_description,
@@ -21,7 +21,7 @@ setup(
         "Source Code": "https://github.com/RaaLabs/TSIClient",
     },
     keywords=["Time Series Insights", "TSI", "TSI SDK", "Raa Labs", "IoT"],
-    install_requires=["requests", "pandas"],
+    install_requires=["requests", "pandas", "azure-identity"],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 setup(
     name="TSIClient",
     packages=find_packages(),
-    version="2.1.0",
+    version="2.1.1",
     license="MIT",
     description="The TSIClient is a Python SDK for Microsoft Azure time series insights.",
     long_description=long_description,


### PR DESCRIPTION
I have updated the TSIClient to use the DefaultAzureCredential. Old way of authenticating is still supported, but a deprecation warning is now displayed when instantiating the TSIClient.

Updated docs are here: <https://raalabs-tsiclient.readthedocs.io/en/default-azure-credential/authentication.html>. Ill update the "latest" version of readthedocs after this PR has been merged.

And the project page on pypi: <https://pypi.org/project/TSIClient/>.

I encouraged the new way of authentication in the README.md as well as in the documentation on readthedocs.