### PR TITLE
Remove deprecate warning

### DIFF
--- a/TSIClient/TSIClient.py
+++ b/TSIClient/TSIClient.py
@@ -71,13 +71,6 @@ class TSIClient():
         self._client_secret = client_secret if client_secret is not None else os.getenv("TSICLIENT_CLIENT_SECRET")
         self._tenant_id = tenant_id if tenant_id is not None else os.getenv("TSICLIENT_TENANT_ID")
 
-        if self._client_id is not None or self._client_secret is not None or self._tenant_id is not None:
-            print("TSIClient deprecation warning:")
-            print("------------------------------")
-            print("Authentication by providing service principal details to the constructor of the TSIClient will be removed in a future version.")
-            print("Authentication with the environmental variables TSICLIENT_CLIENT_ID, TSICLIENT_CLIENT_SECRET and TSICLIENT_TENANT_ID will be removed in a future version")
-            print("Authenticate with the DefaultAzureCredential. Check the docs at readthedocs on how to authenticate with your TSI environment: https://raalabs-tsiclient.readthedocs.io/en/latest/authentication.html.")
-
         allowed_api_versions = ["2020-07-31", "2018-11-01-preview"]
         if api_version in allowed_api_versions:
             self._apiVersion = api_version

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -55,7 +55,7 @@ html_theme = 'sphinx_rtd_theme'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
-html_logo = "RAA_labs_logo_greyscale.png"
+html_logo = "raalabs-logo-blue-yellow-RGB.png"
 html_theme_options = {
     'logo_only': False,
     'display_version': True,

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -27,7 +27,7 @@ the Azure CLI. Follow the docs here: https://docs.microsoft.com/en-us/cli/azure/
 Azure account to authenticate makes use of the `azure-identity` Python library from Microsoft. You can read on the
 supported ways of logging in here: https://docs.microsoft.com/en-us/python/api/overview/azure/identity-readme?view=azure-python
 (authentication with a Visual Studio token disabled for the TSIClient).
-Authentication using a service principal is only recommended when authentication using Azure is not feasibl.
+Authentication using a service principal is only recommended when authentication using Azure is not feasible.
 
 Using Azure account & Azure CLI
 +++++++++++++++++++++++++++++++

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -27,8 +27,10 @@ the Azure CLI. Follow the docs here: https://docs.microsoft.com/en-us/cli/azure/
 Azure account to authenticate makes use of the `azure-identity` Python library from Microsoft. You can read on the
 supported ways of logging in here: https://docs.microsoft.com/en-us/python/api/overview/azure/identity-readme?view=azure-python
 (authentication with a Visual Studio token disabled for the TSIClient).
-Authentication using a service principal is discouraged.
+Authentication using a service principal is only recommended when authentication using Azure is not feasibl.
 
+Using Azure account & Azure CLI
++++++++++++++++++++++++++++++++
 Log in to Azure with the following command:
 
 .. code-block:: console
@@ -50,14 +52,9 @@ the `applicationName` and `environment` arguments:
     ...     api_version="2020-07-31"
     ... )
 
-
-.. warning::
-    Since version 2.1.0 authentication is preferrably done using a `DefaultAzureCredential` from the `azure-identity` package.
-    Authentication by providing constructor arguments or defining these environment variables: `TSICLIENT_CLIENT_ID`, `TSICLIENT_CLIENT_SECRET`, `TSICLIENT_TENANT_ID` will be
-    removed in a future version.
-
-You can still authenticate by passing arguments to the constructor, however,
-this will be removed in a future version. Authentication works through the use of
+Using Azure service principal
++++++++++++++++++++++++++++++
+Authentication works through the use of
 a service principal. When you create the service principal in Azure, make sure to
 note down the details, since you need them to use the TSIClient. Note that one instance
 of the TSIClient can only connect to one TSI environment, if you wish to connect to


### PR DESCRIPTION
## Summary

Removed deprecation warning about service principal authentication (this is required and cannot be deprecated). Fixed link to Raa Labs logo in `conf.py` for Sphinx documentation.