### PR TITLE
New pypi version

### DIFF
--- a/docs/source/raalabs.rst
+++ b/docs/source/raalabs.rst
@@ -21,4 +21,4 @@ This will create a ``build``, ``dist`` and ``TSIClient.egg-info`` folder.
 
 .. code-block:: console
 
-    $ python setup.py sdist bdist_wheel
+    $ twine upload dist/*

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,13 @@ with open("README.md") as f:
 setup(
     name="TSIClient",
     packages=find_packages(),
-    version="2.1.2",
+    version="2.1.3",
     license="MIT",
     description="The TSIClient is a Python SDK for Microsoft Azure time series insights.",
     long_description=long_description,
     long_description_content_type="text/markdown",
     author="Raa Labs",
-    author_email="gill@outlook.com",
+    author_email="post@raalabs.com",
     url="https://github.com/RaaLabs/TSIClient",
     project_urls={
         "Bug Tracker": "https://github.com/RaaLabs/TSIClient/issues",


### PR DESCRIPTION
## Summary

Bump version for pypi publication (new: 2.1.3), correct command in docs to publish pypi versions.