### PR TITLE
Add TSIClient initialization with TSI Environment Id

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ client = tsi.TSIClient(
 )
 ````
 
+or directly with environmentId (GUID, first part of your environments Data Access FQDN)
+
+````python
+from TSIClient import TSIClient as tsi
+
+client = tsi.TSIClient(
+    environmentId="<your-tsi-env-id>",
+    applicationName="<your-app-name>"
+)
+````
+
 You can check the docs at <https://raalabs-tsiclient.readthedocs.io/en/latest/authentication.html> for more information on authentication, and check
 the old way of authentication (these will be removed in a future version).
 

--- a/TSIClient/TSIClient.py
+++ b/TSIClient/TSIClient.py
@@ -59,6 +59,7 @@ class TSIClient():
     def __init__(
             self,
             environment=None,
+            environmentId=None,
             client_id=None,
             client_secret=None,
             applicationName=None,
@@ -67,6 +68,7 @@ class TSIClient():
         ):
         self._applicationName = applicationName if applicationName is not None else os.getenv("TSICLIENT_APPLICATION_NAME")
         self._environmentName = environment if environment is not None else os.getenv("TSICLIENT_ENVIRONMENT_NAME")
+        self._environmentId = environmentId if environmentId is not None else os.getenv("TSICLIENT_ENVIRONMENT_ID")
         self._client_id = client_id if client_id is not None else os.getenv("TSICLIENT_CLIENT_ID")
         self._client_secret = client_secret if client_secret is not None else os.getenv("TSICLIENT_CLIENT_SECRET")
         self._tenant_id = tenant_id if tenant_id is not None else os.getenv("TSICLIENT_TENANT_ID")
@@ -95,6 +97,7 @@ class TSIClient():
         self.environment = EnvironmentApi(
             application_name = self._applicationName,
             environment = self._environmentName,
+            environmentId = self._environmentId,
             authorization_api = self.authorization,
             common_funcs = self.common_funcs
         )

--- a/TSIClient/environment/environment_api.py
+++ b/TSIClient/environment/environment_api.py
@@ -11,11 +11,13 @@ class EnvironmentApi:
         self,
         application_name: str,
         environment: str,
+        environmentId: str,
         authorization_api: AuthorizationApi,
         common_funcs: CommonFuncs,
     ):
         self._applicationName = application_name
         self._environmentName = environment
+        self._environmentId = environmentId
         self.authorization_api = authorization_api
         self.common_funcs = common_funcs
 
@@ -34,6 +36,29 @@ class EnvironmentApi:
             >>> client = tsi.TSIClient()
             >>> env = client.environment.getEnvironmentId()
         """
+        
+        # if environmentId is specified during client initiation, no need to fetch it
+        if (self._environmentId is not None):
+            # check if the environment exists
+            try:
+                authorizationToken = self.authorization_api._getToken()
+                url = f"https://{self._environmentId}.env.timeseries.azure.com/availability?api-version=2020-07-31"
+                headers = {
+                    "Authorization": authorizationToken,
+                }
+
+                response = requests.request(
+                "GET",
+                url,
+                headers=headers,
+                timeout=10,
+                )
+
+                response.raise_for_status()
+                return self._environmentId
+            except:
+                logging.error(f"TSIClient: Error accessing TSI environment with ID {self._environmentId}")
+                raise TSIEnvironmentError(f"TSIClient: Error accessing TSI environment with ID {self._environmentId}")
 
         authorizationToken = self.authorization_api._getToken()
         url = "https://api.timeseries.azure.com/environments"


### PR DESCRIPTION
Instead of looping through all environments, add possibility to directly specify environment id. This is useful (and required) for environments with multiple TSI environments with the same Environment Name.